### PR TITLE
Removes PyQt5 dependency from setup.py, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,14 @@
 Copyright (c) 2022 Marcel Goldschen-Ohm  
 
 # INSTALL
+1. Ensure PyQt5 or PyQt6 is installed for your current enviroment.
+2. `pip install git+https://github.com/marcel-goldschen-ohm/PyQtImageViewer`
 
-Everything's in `QtImageViewer.py` and `QtImageStackViewer.py`. Just put these somewhere where your project can find them.
-
-Additionally, QtImageViewer.py can be installed using the following pip command.
-
-`pip install git+https://github.com/marcel-goldschen-ohm/PyQtImageViewer`
+Everything required to run this package can also be found in `QtImageViewer.py` and `QtImageStackViewer.py`. Just put these somewhere where your project can find them.
 
 ### Requirements:
 
-* [PyQt6 or PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro)
+* [PyQt6 or PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) - Not included in setup.py requirements due to macOS/Linux install issues for Apple Silicon Devices
 * [NumPy](https://numpy.org/)
 * [Pillow](https://python-pillow.org)
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
     ],
 
     ### Dependencies
-    # removed PyQt5 dependance for testing purposes.
 
     install_requires=[
         'numpy',

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ setup(
     ],
 
     ### Dependencies
+    # removed PyQt5 dependance for testing purposes.
 
     install_requires=[
-        'PyQt5',
         'numpy',
         'Pillow',
     ],


### PR DESCRIPTION
PyQt5 dependency in the setup.py file was driving errors for macOS. 